### PR TITLE
Update test runner to Groovy 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tests/**/.gradle/
 tests/**/*.groovy.original
 target/
 jansi-tmp/
+tmp

--- a/bin/run-in-docker.sh
+++ b/bin/run-in-docker.sh
@@ -32,7 +32,7 @@ mkdir -p "${output_dir}"
 
 # Build the Docker image
 if [[ "${BUILD_IMAGE:-true}" == "true" ]]; then
-  docker build --rm -t exercism/groovy-test-runner .
+    docker build --rm -t exercism/groovy-test-runner .
 fi
 
 # Run the Docker image using the settings mimicking the production environment

--- a/bin/run-in-docker.sh
+++ b/bin/run-in-docker.sh
@@ -31,7 +31,9 @@ output_dir="${3%/}"
 mkdir -p "${output_dir}"
 
 # Build the Docker image
-docker build --rm -t exercism/groovy-test-runner .
+if [[ "${BUILD_IMAGE:-true}" == "true" ]]; then
+  docker build --rm -t exercism/groovy-test-runner .
+fi
 
 # Run the Docker image using the settings mimicking the production environment
 docker run \

--- a/bin/run-reference-solution-tests-in-docker.sh
+++ b/bin/run-reference-solution-tests-in-docker.sh
@@ -34,7 +34,7 @@ failures=()
 
 # Iterate over all exercises directories
 for exercise_dir in "${groovy_repo_path}"/exercises/practice/*; do
-    exercise_slug=$(basename "${exercise_dir}")
+    exercise_slug="${exercise_dir##*/}"
     exercise_tmp_dir="${tmp_dir}/${exercise_slug}"
     mkdir -p "${exercise_tmp_dir}"
     cp -R "${exercise_dir}/" "${exercise_tmp_dir}"
@@ -49,7 +49,7 @@ for exercise_dir in "${groovy_repo_path}"/exercises/practice/*; do
     fi
 done
 
-if [[ -z "${#failures[@]}" ]]; then
+if [[ "${#failures[@]}" != 0 ]]; then
     echo "💥 The following exercises failed: ${failures[*]}"
     echo "Check above for details"
     exit 1

--- a/bin/run-reference-solution-tests-in-docker.sh
+++ b/bin/run-reference-solution-tests-in-docker.sh
@@ -30,6 +30,8 @@ cleanup() {
 
 trap cleanup EXIT
 
+failures=()
+
 # Iterate over all exercises directories
 for exercise_dir in "${groovy_repo_path}"/exercises/practice/*; do
     exercise_slug=$(basename "${exercise_dir}")
@@ -41,10 +43,16 @@ for exercise_dir in "${groovy_repo_path}"/exercises/practice/*; do
     results_json="${exercise_tmp_dir}/output/results.json"
     status=$(jq -r ".status" "${results_json}")
     if [[ "${status}" != "pass" ]]; then
-        echo "💥 Test failed for ${exercise_slug}, check the output in ${results_json}"
+        echo "💥 Test failed for ${exercise_slug}:"
         jq . "${results_json}"
-        exit 1
+        failures+=("${exercise_slug}")
     fi
 done
+
+if [[ -z "${#failures[@]}" ]]; then
+    echo "💥 The following exercises failed: ${failures[*]}"
+    echo "Check above for details"
+    exit 1
+fi
 
 echo "✅ All tests passed"

--- a/bin/run-reference-solution-tests-in-docker.sh
+++ b/bin/run-reference-solution-tests-in-docker.sh
@@ -24,18 +24,18 @@ rm -r "${repo_root}/tmp" || true
 
 # Iterate over all exercises directories
 for exercise_dir in "${groovy_repo_path}"/exercises/practice/*; do
-  exercise_slug=$(basename "${exercise_dir}")
-  exercise_tmp_dir="${repo_root}/tmp/${exercise_slug}"
-  mkdir -p "${exercise_tmp_dir}"
-  cp -R "${exercise_dir}/" "${exercise_tmp_dir}"
-  cp -R "${exercise_dir}/.meta/src/reference/" "${exercise_tmp_dir}/src/main"
-  eval "${repo_root}/bin/run-in-docker.sh" "${exercise_slug}" "${exercise_tmp_dir}" "${exercise_tmp_dir}/output"
-  results_json="${exercise_tmp_dir}/output/results.json"
-  status=$(jq -r ".status" "${results_json}")
-  if [[ "${status}" != "pass" ]]; then
-    echo "💥 Test failed for ${exercise_slug}, check the output in ${results_json}"
-    exit 1
-  fi
+    exercise_slug=$(basename "${exercise_dir}")
+    exercise_tmp_dir="${repo_root}/tmp/${exercise_slug}"
+    mkdir -p "${exercise_tmp_dir}"
+    cp -R "${exercise_dir}/" "${exercise_tmp_dir}"
+    cp -R "${exercise_dir}/.meta/src/reference/" "${exercise_tmp_dir}/src/main"
+    eval "${repo_root}/bin/run-in-docker.sh" "${exercise_slug}" "${exercise_tmp_dir}" "${exercise_tmp_dir}/output"
+    results_json="${exercise_tmp_dir}/output/results.json"
+    status=$(jq -r ".status" "${results_json}")
+    if [[ "${status}" != "pass" ]]; then
+        echo "💥 Test failed for ${exercise_slug}, check the output in ${results_json}"
+        exit 1
+    fi
 done
 
 echo "✅ All tests passed"

--- a/bin/run-reference-solution-tests-in-docker.sh
+++ b/bin/run-reference-solution-tests-in-docker.sh
@@ -49,7 +49,7 @@ for exercise_dir in "${groovy_repo_path}"/exercises/practice/*; do
     fi
 done
 
-if [[ "${#failures[@]}" != 0 ]]; then
+if (( "${#failures[@]}" != 0 )); then
     echo "💥 The following exercises failed: ${failures[*]}"
     echo "Check above for details"
     exit 1

--- a/bin/run-reference-solution-tests-in-docker.sh
+++ b/bin/run-reference-solution-tests-in-docker.sh
@@ -39,7 +39,7 @@ for exercise_dir in "${groovy_repo_path}"/exercises/practice/*; do
     mkdir -p "${exercise_tmp_dir}"
     cp -R "${exercise_dir}/" "${exercise_tmp_dir}"
     cp -R "${exercise_dir}/.meta/src/reference/" "${exercise_tmp_dir}/src/main"
-    eval "${repo_root}/bin/run-in-docker.sh" "${exercise_slug}" "${exercise_tmp_dir}" "${exercise_tmp_dir}/output"
+    "${repo_root}/bin/run-in-docker.sh" "${exercise_slug}" "${exercise_tmp_dir}" "${exercise_tmp_dir}/output"
     results_json="${exercise_tmp_dir}/output/results.json"
     status=$(jq -r ".status" "${results_json}")
     if [[ "${status}" != "pass" ]]; then

--- a/bin/run-reference-solution-tests-in-docker.sh
+++ b/bin/run-reference-solution-tests-in-docker.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Synopsis:
+# Test the test runner Docker image by running it against all reference solutions from the Groovy repository.
+# It is recommended to run this script when upgrading Groovy exercises or Groovy test runner dependencies.
+
+# Output:
+# Fails is
+
+# Example:
+# ./bin/run-reference-solution-tests-in-docker.sh
+
+# Build the Docker image
+docker build --rm -t exercism/groovy-test-runner .
+export BUILD_IMAGE=false
+
+# Assumes exercism/groovy repository is checked out next to the exercism/groovy-test-runner repository.
+# If the repository is checked out elsewhere, provide the path as the first argument.
+groovy_repo_path=$(realpath "${1:-${PWD}/../groovy}")
+repo_root=$(git rev-parse --show-toplevel)
+rm -r "${repo_root}/tmp" || true
+
+# Iterate over all exercises directories
+for exercise_dir in "${groovy_repo_path}"/exercises/practice/*; do
+  exercise_slug=$(basename "${exercise_dir}")
+  exercise_tmp_dir="${repo_root}/tmp/${exercise_slug}"
+  mkdir -p "${exercise_tmp_dir}"
+  cp -R "${exercise_dir}/" "${exercise_tmp_dir}"
+  cp -R "${exercise_dir}/.meta/src/reference/" "${exercise_tmp_dir}/src/main"
+  eval "${repo_root}/bin/run-in-docker.sh" "${exercise_slug}" "${exercise_tmp_dir}" "${exercise_tmp_dir}/output"
+  results_json="${exercise_tmp_dir}/output/results.json"
+  status=$(jq -r ".status" "${results_json}")
+  if [[ "${status}" != "pass" ]]; then
+    echo "💥 Test failed for ${exercise_slug}, check the output in ${results_json}"
+    exit 1
+  fi
+done
+
+echo "✅ All tests passed"

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,6 @@ repositories {
 }
 
 dependencies {
-    implementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
-    implementation "org.codehaus.groovy:groovy-all:3.0.2"
+    implementation "org.spockframework:spock-core:2.3-groovy-4.0"
+    implementation "org.apache.groovy:groovy:4.0.24"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <groovy.version>3.0.8</groovy.version>
+    <groovy.version>4.0.24</groovy.version>
+    <spock.version>2.3-groovy-4.0</spock.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
   </properties>
@@ -20,14 +21,13 @@
     <dependency>
       <groupId>org.spockframework</groupId>
       <artifactId>spock-core</artifactId>
-      <version>2.0-groovy-3.0</version>
+      <version>${spock.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
-      <version>3.0.8</version>
-      <type>pom</type>
+      <groupId>org.apache.groovy</groupId>
+      <artifactId>groovy</artifactId>
+      <version>${groovy.version}</version>
     </dependency>
   </dependencies>
 
@@ -91,7 +91,7 @@
         visit https://github.com/groovy/GMavenPlus/wiki -->
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>
-        <version>1.13.0</version>
+        <version>4.0.1</version>
         <executions>
           <execution>
             <goals>

--- a/tests/example-all-fail/build.gradle
+++ b/tests/example-all-fail/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
-    implementation "org.codehaus.groovy:groovy-all:3.0.2"
+    testImplementation "org.spockframework:spock-core:2.3-groovy-4.0"
+    implementation "org.apache.groovy:groovy:4.0.24"
 }
 
 test {

--- a/tests/example-empty-file/build.gradle
+++ b/tests/example-empty-file/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
-    implementation "org.codehaus.groovy:groovy-all:3.0.2"
+    testImplementation "org.spockframework:spock-core:2.3-groovy-4.0"
+    implementation "org.apache.groovy:groovy:4.0.24"
 }
 
 test {

--- a/tests/example-partial-fail/build.gradle
+++ b/tests/example-partial-fail/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
-    implementation "org.codehaus.groovy:groovy-all:3.0.2"
+    testImplementation "org.spockframework:spock-core:2.3-groovy-4.0"
+    implementation "org.apache.groovy:groovy:4.0.24"
 }
 
 test {

--- a/tests/example-success/build.gradle
+++ b/tests/example-success/build.gradle
@@ -5,6 +5,6 @@ repositories {
 }
 
 dependencies {
-    implementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
-    implementation "org.codehaus.groovy:groovy-all:3.0.2"
+    implementation "org.spockframework:spock-core:2.3-groovy-4.0"
+    implementation "org.apache.groovy:groovy:4.0.24"
 }

--- a/tests/example-syntax-error/build.gradle
+++ b/tests/example-syntax-error/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
-    implementation "org.codehaus.groovy:groovy-all:3.0.2"
+    testImplementation "org.spockframework:spock-core:2.3-groovy-4.0"
+    implementation "org.codehaus.groovy:groovy:4.0.24"
 }
 
 test {


### PR DESCRIPTION
# Groovy 4

## Changes

- Groovy 4
- Spock 2.3
- A script to verify reference solutions work

## Comments

- I didn't find any backward-incompatible language features in [Groovy 4 release notes](https://www.groovy-lang.org/releasenotes/groovy-4.0.html), so it should be fine to temporarily have the test runner ahead of the local dependencies in the Groovy track. The PR to update the Gradle files will follow up shortly.
- `groovy-test-runner` caches its dependencies via Maven and can be upgraded independently from the Gradle dependencies in the [groovy](https://github.com/exercism/groovy) repository.
- This PR changes Groovy dependency from `groovy-all` to just `groovy`, but that should be fine since the exercises should depend on core language features, not on extra libraries (e.g., `groovy-json` or `groovy-xml`). At least the reference solutions do not - see `run-reference-solution-tests-in-docker.sh` script and the proof of work for more details.
- Since `run-reference-solution-tests-in-docker.sh` relies on an external repository ([groovy](https://github.com/exercism/groovy)) checked out, I only ran it manually but omitted adding it to CI

## Proof of work

<details>
<summary>./bin/run-reference-solution-tests-in-docker.sh</summary>

```
#0 building with "desktop-linux" instance using docker driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 746B done
#1 DONE 0.0s

#2 [internal] load metadata for docker.io/library/maven:3.8.3-jdk-11
#2 ...

#3 [auth] library/maven:pull token for registry-1.docker.io
#3 DONE 0.0s

#4 [internal] load metadata for docker.io/library/maven:3.8.3-jdk-11-slim
#4 DONE 1.4s

#2 [internal] load metadata for docker.io/library/maven:3.8.3-jdk-11
#2 DONE 1.4s

#5 [internal] load .dockerignore
#5 transferring context: 121B done
#5 DONE 0.0s

#6 [cache 1/5] FROM docker.io/library/maven:3.8.3-jdk-11@sha256:efaeca6b14ed6e05b2923416eebddd78c0e175a24580a29ca1d8a4c1ece196b2
#6 DONE 0.0s

#7 [stage-1 1/6] FROM docker.io/library/maven:3.8.3-jdk-11-slim@sha256:a4c3091b7de4b95fff1c947c11c35384e6e99cb09a79b8fcf5844eeea1de5f02
#7 DONE 0.0s

#8 [internal] load build context
#8 transferring context: 15.85kB 0.1s done
#8 DONE 0.1s

#9 [stage-1 2/6] WORKDIR /opt/test-runner
#9 CACHED

#10 [stage-1 3/6] RUN apt-get update &&     apt-get install -y jq &&     apt-get purge --auto-remove -y &&     apt-get clean &&     rm -rf /var/lib/apt/lists/*
#10 CACHED

#11 [cache 4/5] COPY pom.xml .
#11 CACHED

#12 [cache 3/5] COPY src/ src/
#12 CACHED

#13 [cache 2/5] WORKDIR /opt/exercise
#13 CACHED

#14 [cache 5/5] RUN mvn test dependency:go-offline -DexcludeReactor=false
#14 CACHED

#15 [stage-1 4/6] COPY . .
#15 DONE 0.1s

#16 [stage-1 5/6] COPY --from=cache /root/.m2 /root/.m2
#16 DONE 0.5s

#17 [stage-1 6/6] COPY --from=cache /opt/exercise/pom.xml /root/pom.xml
#17 DONE 0.0s

#18 exporting to image
#18 exporting layers 0.1s done
#18 writing image sha256:32452c3ebc175dd76b8aee442039ef47cca60b71fee3163393d0a97bad42ccc8 done
#18 naming to docker.io/exercism/groovy-test-runner done
#18 DONE 0.1s
rm: /Users/kirill/workspace/exercism/source/groovy-test-runner/tmp: No such file or directory
accumulate: testing...
accumulate: done
acronym: testing...
acronym: done
all-your-base: testing...
all-your-base: done
allergies: testing...
allergies: done
anagram: testing...
anagram: done
armstrong-numbers: testing...
armstrong-numbers: done
atbash-cipher: testing...
atbash-cipher: done
bank-account: testing...
bank-account: done
binary-search: testing...
binary-search: done
bob: testing...
bob: done
circular-buffer: testing...
circular-buffer: done
collatz-conjecture: testing...
collatz-conjecture: done
darts: testing...
darts: done
difference-of-squares: testing...
difference-of-squares: done
dnd-character: testing...
dnd-character: done
eliuds-eggs: testing...
eliuds-eggs: done
etl: testing...
etl: done
flatten-array: testing...
flatten-array: done
gigasecond: testing...
gigasecond: done
grains: testing...
grains: done
hamming: testing...
hamming: done
hello-world: testing...
hello-world: done
high-scores: testing...
high-scores: done
isbn-verifier: testing...
isbn-verifier: done
isogram: testing...
isogram: done
largest-series-product: testing...
largest-series-product: done
leap: testing...
leap: done
linked-list: testing...
cp: cannot stat '/solution/src/test/groovy/LinkedListSpec.groovy': No such file or directory
sed: can't read /solution/src/test/groovy/LinkedListSpec.groovy: No such file or directory
sed: can't read /solution/src/test/groovy/LinkedListSpec.groovy: No such file or directory
mv: cannot stat '/solution/src/test/groovy/LinkedListSpec.groovy.original': No such file or directory
linked-list: done
list-ops: testing...
list-ops: done
luhn: testing...
luhn: done
matching-brackets: testing...
matching-brackets: done
matrix: testing...
matrix: done
nth-prime: testing...
nth-prime: done
nucleotide-count: testing...
nucleotide-count: done
pangram: testing...
pangram: done
pascals-triangle: testing...
pascals-triangle: done
perfect-numbers: testing...
perfect-numbers: done
phone-number: testing...
phone-number: done
pig-latin: testing...
pig-latin: done
prime-factors: testing...
prime-factors: done
protein-translation: testing...
protein-translation: done
proverb: testing...
proverb: done
queen-attack: testing...
queen-attack: done
raindrops: testing...
raindrops: done
resistor-color: testing...
resistor-color: done
resistor-color-duo: testing...
resistor-color-duo: done
resistor-color-trio: testing...
resistor-color-trio: done
reverse-string: testing...
reverse-string: done
rna-transcription: testing...
rna-transcription: done
robot-name: testing...
robot-name: done
robot-simulator: testing...
robot-simulator: done
roman-numerals: testing...
roman-numerals: done
rotational-cipher: testing...
rotational-cipher: done
run-length-encoding: testing...
run-length-encoding: done
saddle-points: testing...
saddle-points: done
scrabble-score: testing...
scrabble-score: done
secret-handshake: testing...
secret-handshake: done
series: testing...
series: done
sieve: testing...
sieve: done
space-age: testing...
space-age: done
square-root: testing...
square-root: done
strain: testing...
strain: done
sum-of-multiples: testing...
sum-of-multiples: done
triangle: testing...
triangle: done
two-fer: testing...
two-fer: done
word-count: testing...
word-count: done
yacht: testing...
yacht: done
✅ All tests passed
```

</details>