### PR TITLE
Bump JDK to 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # === Build maven cache ===
 
-FROM maven:3.8.3-jdk-11 AS cache
+FROM maven:3.8.5-openjdk-17 AS cache
 
 # Ensure exercise dependencies are downloaded
 WORKDIR /opt/exercise
@@ -10,7 +10,7 @@ RUN mvn test dependency:go-offline -DexcludeReactor=false
 
 # === Build runtime image ===
 
-FROM maven:3.8.3-jdk-11-slim
+FROM maven:3.8.5-openjdk-17-slim
 WORKDIR /opt/test-runner
 
 RUN apt-get update && \


### PR DESCRIPTION
Latest available stable openJDK

Before:
> exercism/groovy-test-runner   latest    b2195c6ba555   9 minutes ago    487MB

After:
> exercism/groovy-test-runner   latest    385e423671b9   25 minutes ago   468MB