### PR TITLE
Bump JDK to 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ FROM maven:3.9.9-eclipse-temurin-21-alpine
 WORKDIR /opt/test-runner
 
 RUN apk update && \
-        apk add --no-cache jq && \
+        apk add --no-cache --upgrade jq sed grep && \
         rm -rf /var/cache/apk/*
 
 # Copy resources

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # === Build maven cache ===
 
-FROM maven:3.8.3-jdk-11 AS cache
+FROM maven:3.9.9-eclipse-temurin-21 AS cache
 
 # Ensure exercise dependencies are downloaded
 WORKDIR /opt/exercise
@@ -10,14 +10,12 @@ RUN mvn test dependency:go-offline -DexcludeReactor=false
 
 # === Build runtime image ===
 
-FROM maven:3.8.3-jdk-11-slim
+FROM maven:3.9.9-eclipse-temurin-21-alpine
 WORKDIR /opt/test-runner
 
-RUN apt-get update && \
-    apt-get install -y jq && \
-    apt-get purge --auto-remove -y && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk update && \
+        apk add --no-cache jq && \
+        rm -rf /var/cache/apk/*
 
 # Copy resources
 COPY . .

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -103,7 +103,7 @@ else
 
     # Manually add colors to the output to help scanning the output for errors
     colorized_test_output=$(echo "${sanitized_output}" | \
-        GREP_COLOR='01;31' grep --color=always -E -e '^\[ERROR\].+$|$')
+        GREP_COLORS='mt=01;31' grep --color=always -E -e '^\[ERROR\].+$|$')
 
     jq -n --arg output "${colorized_test_output}" '{version: 1, status: "fail", message: $output}' > ${results_file}
 fi

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -70,7 +70,7 @@ export JAVA_TOOL_OPTIONS="-Djansi.tmpdir=/solution/jansi-tmp -Xss128m -Xms256m -
 rm -rf target
 # Run the tests for the provided implementation file and redirect stdout and
 # stderr to capture it
-test_output=$(mvn --offline --legacy-local-repository --batch-mode --non-recursive --quiet test 2>&1)
+test_output=$(mvn --offline --batch-mode --non-recursive --quiet test 2>&1)
 exit_code=$?
 
 rm -f pom.xml


### PR DESCRIPTION
Switch to eclipse-temurin/alpine, since jdk/slim is deprecated by maven Docker repository

Before:
> exercism/groovy-test-runner   latest    b2195c6ba555   9 minutes ago    487MB

After:
> exercism/groovy-test-runner   latest    b04d0d88120c   19 seconds ago      474MB

<details>
<summary>./bin/run-reference-solution-tests-in-docker.sh</summary>

```
#0 building with "desktop-linux" instance using docker driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 709B done
#1 DONE 0.0s

#2 [internal] load metadata for docker.io/library/maven:3.9.9-eclipse-temurin-21-alpine
#2 ...

#3 [auth] library/maven:pull token for registry-1.docker.io
#3 DONE 0.0s

#4 [internal] load metadata for docker.io/library/maven:3.9.9-eclipse-temurin-21
#4 DONE 1.1s

#2 [internal] load metadata for docker.io/library/maven:3.9.9-eclipse-temurin-21-alpine
#2 DONE 1.1s

#5 [internal] load .dockerignore
#5 transferring context: 121B done
#5 DONE 0.0s

#6 [cache 1/5] FROM docker.io/library/maven:3.9.9-eclipse-temurin-21@sha256:b89ede2635fb8ebd9ba7a3f7d56140f2bd31337b8b0e9fa586b657ee003307a7
#6 DONE 0.0s

#7 [stage-1 1/6] FROM docker.io/library/maven:3.9.9-eclipse-temurin-21-alpine@sha256:80c937fd8bb9df3f0603dfe39f9961b45b98287d5e9f9207779bc92ffd4e0abc
#7 DONE 0.0s

#8 [internal] load build context
#8 transferring context: 7.28kB done
#8 DONE 0.0s

#9 [stage-1 2/6] WORKDIR /opt/test-runner
#9 CACHED

#10 [stage-1 3/6] RUN apk update &&         apk add --no-cache jq &&         rm -rf /var/cache/apk/*
#10 CACHED

#11 [cache 2/5] WORKDIR /opt/exercise
#11 CACHED

#12 [cache 4/5] COPY pom.xml .
#12 CACHED

#13 [cache 3/5] COPY src/ src/
#13 CACHED

#14 [cache 5/5] RUN mvn test dependency:go-offline -DexcludeReactor=false
#14 CACHED

#15 [stage-1 4/6] COPY . .
#15 DONE 0.0s

#16 [stage-1 5/6] COPY --from=cache /root/.m2 /root/.m2
#16 DONE 0.6s

#17 [stage-1 6/6] COPY --from=cache /opt/exercise/pom.xml /root/pom.xml
#17 DONE 0.0s

#18 exporting to image
#18 exporting layers
#18 exporting layers 0.2s done
#18 writing image sha256:4567d4b7786033759962c32b48e39600818793e41089b942c85e0424e23aca9d
#18 writing image sha256:4567d4b7786033759962c32b48e39600818793e41089b942c85e0424e23aca9d done
#18 naming to docker.io/exercism/groovy-test-runner 0.0s done
#18 DONE 0.2s
Using temporary directory: /var/folders/ml/d832kdw50ms20v_m0zdv6xw80000gp/T/tmp.wkBrWiJtaE
accumulate: testing...
accumulate: done
acronym: testing...
acronym: done
all-your-base: testing...
all-your-base: done
allergies: testing...
allergies: done
anagram: testing...
anagram: done
armstrong-numbers: testing...
armstrong-numbers: done
atbash-cipher: testing...
atbash-cipher: done
bank-account: testing...
bank-account: done
binary-search: testing...
binary-search: done
bob: testing...
bob: done
circular-buffer: testing...
circular-buffer: done
collatz-conjecture: testing...
collatz-conjecture: done
darts: testing...
darts: done
difference-of-squares: testing...
difference-of-squares: done
dnd-character: testing...
dnd-character: done
eliuds-eggs: testing...
eliuds-eggs: done
etl: testing...
etl: done
flatten-array: testing...
flatten-array: done
gigasecond: testing...
gigasecond: done
grains: testing...
grains: done
hamming: testing...
hamming: done
hello-world: testing...
hello-world: done
high-scores: testing...
high-scores: done
isbn-verifier: testing...
isbn-verifier: done
isogram: testing...
isogram: done
largest-series-product: testing...
largest-series-product: done
leap: testing...
leap: done
linked-list: testing...
linked-list: done
list-ops: testing...
list-ops: done
luhn: testing...
luhn: done
matching-brackets: testing...
matching-brackets: done
matrix: testing...
matrix: done
nth-prime: testing...
nth-prime: done
nucleotide-count: testing...
nucleotide-count: done
pangram: testing...
pangram: done
pascals-triangle: testing...
pascals-triangle: done
perfect-numbers: testing...
perfect-numbers: done
phone-number: testing...
phone-number: done
pig-latin: testing...
pig-latin: done
prime-factors: testing...
prime-factors: done
protein-translation: testing...
protein-translation: done
proverb: testing...
proverb: done
queen-attack: testing...
queen-attack: done
raindrops: testing...
raindrops: done
resistor-color: testing...
resistor-color: done
resistor-color-duo: testing...
resistor-color-duo: done
resistor-color-trio: testing...
resistor-color-trio: done
reverse-string: testing...
reverse-string: done
rna-transcription: testing...
rna-transcription: done
robot-name: testing...
robot-name: done
robot-simulator: testing...
robot-simulator: done
roman-numerals: testing...
roman-numerals: done
rotational-cipher: testing...
rotational-cipher: done
run-length-encoding: testing...
run-length-encoding: done
saddle-points: testing...
saddle-points: done
scrabble-score: testing...
scrabble-score: done
secret-handshake: testing...
secret-handshake: done
series: testing...
series: done
sieve: testing...
sieve: done
space-age: testing...
space-age: done
square-root: testing...
square-root: done
strain: testing...
strain: done
sum-of-multiples: testing...
sum-of-multiples: done
triangle: testing...
triangle: done
two-fer: testing...
two-fer: done
word-count: testing...
word-count: done
yacht: testing...
yacht: done
✅ All tests passed
```

</details>